### PR TITLE
Added PromptCacheKey, SafetyIdentifier, and Verbosity properties to OpenAIChatRequest

### DIFF
--- a/src/Zatomic.AI.Providers/OpenAI/OpenAIChatRequest.cs
+++ b/src/Zatomic.AI.Providers/OpenAI/OpenAIChatRequest.cs
@@ -38,11 +38,17 @@ namespace Zatomic.AI.Providers.OpenAI
 		[JsonProperty("presence_penalty", NullValueHandling = NullValueHandling.Ignore)]
 		public float? PresencePenalty { get; set; }
 
+		[JsonProperty("prompt_cache_key", NullValueHandling = NullValueHandling.Ignore)]
+		public string PromptCacheKey { get; set; }
+
 		[JsonProperty("reasoning_effort", NullValueHandling = NullValueHandling.Ignore)]
 		public string ReasoningEffort { get; set; }
 
 		[JsonProperty("response_format", NullValueHandling = NullValueHandling.Ignore)]
 		public OpenAIChatResponseFormat ResponseFormat { get; set; }
+
+		[JsonProperty("safety_identifier", NullValueHandling = NullValueHandling.Ignore)]
+		public string SafetyIdentifier { get; set; }
 
 		[JsonProperty("seed", NullValueHandling = NullValueHandling.Ignore)]
 		public decimal? Seed { get; set; }
@@ -76,6 +82,9 @@ namespace Zatomic.AI.Providers.OpenAI
 
 		[JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]
 		public string User { get; set; }
+
+		[JsonProperty("verbosity", NullValueHandling = NullValueHandling.Ignore)]
+		public string Verbosity { get; set; }
 
 		[JsonProperty("web_search_options", NullValueHandling = NullValueHandling.Ignore)]
 		public OpenAIChatWebSearchOptions WebSearchOptions { get; set; }

--- a/src/Zatomic.AI.Providers/Zatomic.AI.Providers.csproj
+++ b/src/Zatomic.AI.Providers/Zatomic.AI.Providers.csproj
@@ -10,7 +10,7 @@
     <Description>.NET SDK for integrating with various AI model providers.</Description>
     <RepositoryUrl>https://github.com/ZatomicAI/Zatomic.AI.Providers</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <RepositoryType>git</RepositoryType>
     <PackageTags>AI21Labs;Anthropic;AmazonBedrock;AzureOpenAI;AzureServerless;Cohere;DeepInfra;FireworksAI;GoogleGemini;Groq;HuggingFace;Hyperbolic;Meta;Mistral;MoonshotAI;Lambda;OpenAI;Perplexity;TogetherAI;xAI</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
This pull request adds new optional properties to the `OpenAIChatRequest` class to support enhanced request customization, and bumps the package version to 2.11.0.

Enhancements to `OpenAIChatRequest`:

* Added `PromptCacheKey` and `SafetyIdentifier` properties to allow for prompt caching and safety tracking in chat requests.
* Added `Verbosity` property to enable control over the verbosity level of responses.

Versioning:

* Updated the package version in `Zatomic.AI.Providers.csproj` from 2.10.0 to 2.11.0 to reflect these new features.