### PR TITLE
Added support to add request headers for Amazon Bedrock calls

### DIFF
--- a/src/Zatomic.AI.Providers/AmazonBedrock/AmazonBedrockChatClient.cs
+++ b/src/Zatomic.AI.Providers/AmazonBedrock/AmazonBedrockChatClient.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Amazon;
 using Amazon.BedrockRuntime;
 using Amazon.BedrockRuntime.Model;
+using Amazon.Runtime;
 using Zatomic.AI.Providers.Exceptions;
 using Zatomic.AI.Providers.Extensions;
 
@@ -17,9 +18,11 @@ namespace Zatomic.AI.Providers.AmazonBedrock
 		public string AccessKey { get; set; }
 		public string Region { get; set; }
 		public string SecretKey { get; set; }
+		public Dictionary<string, string> RequestHeaders { get; set; }
 
 		public AmazonBedrockChatClient()
 		{
+			RequestHeaders = new Dictionary<string, string>();
 		}
 
 		public AmazonBedrockChatClient(string accessKey, string secretKey, string region) : this()
@@ -27,6 +30,11 @@ namespace Zatomic.AI.Providers.AmazonBedrock
 			AccessKey = accessKey;
 			SecretKey = secretKey;
 			Region = region;
+		}
+
+		public void AddRequestHeader(string key, string value)
+		{
+			RequestHeaders.Add(key, value);
 		}
 
 		public async Task<AmazonBedrockChatResponse> ChatAsync(AmazonBedrockChatRequest request)
@@ -126,6 +134,17 @@ namespace Zatomic.AI.Providers.AmazonBedrock
 		{
 			var bedrockConfig = new AmazonBedrockRuntimeConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(Region) };
 			_runtimeClient = new AmazonBedrockRuntimeClient(AccessKey, SecretKey, bedrockConfig);
+
+			foreach (var header in RequestHeaders)
+			{
+				_runtimeClient.BeforeRequestEvent += (sender, args) =>
+				{
+					if (args is WebServiceRequestEventArgs requestArgs)
+					{
+						requestArgs.Headers[header.Key] = header.Value;
+					}
+				};
+			}
 		}
 
 		private ConverseRequest ConvertToConverseRequest(AmazonBedrockChatRequest request)

--- a/src/Zatomic.AI.Providers/Zatomic.AI.Providers.csproj
+++ b/src/Zatomic.AI.Providers/Zatomic.AI.Providers.csproj
@@ -10,7 +10,7 @@
     <Description>.NET SDK for integrating with various AI model providers.</Description>
     <RepositoryUrl>https://github.com/ZatomicAI/Zatomic.AI.Providers</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <RepositoryType>git</RepositoryType>
     <PackageTags>AI21Labs;Anthropic;AmazonBedrock;AzureOpenAI;AzureServerless;Cohere;DeepInfra;FireworksAI;GoogleGemini;Groq;HuggingFace;Hyperbolic;IBMWatsonX;Inception;Mistral;MoonshotAI;Nvidia;OpenAI;Perplexity;TogetherAI;xAI</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
This pull request adds support for custom request headers in the `AmazonBedrockChatClient`, allowing users to specify additional headers for each request to Amazon Bedrock. It also bumps the package version to 5.1.0 to reflect the new feature.

**Amazon Bedrock Client Enhancements:**

* Added a `RequestHeaders` property to `AmazonBedrockChatClient` and initialized it in the constructor, enabling users to store custom headers.
* Introduced an `AddRequestHeader` method to simplify adding custom headers to the client.
* Modified the `InitializeRuntimeClient` method to attach all custom headers to outgoing requests by hooking into the `BeforeRequestEvent` of the runtime client.

**Project Versioning:**

* Updated the NuGet package version to `5.1.0` in `Zatomic.AI.Providers.csproj` to reflect the new feature addition.